### PR TITLE
Add: Auto Notes Remover

### DIFF
--- a/great_with_copyrights.he
+++ b/great_with_copyrights.he
@@ -1,0 +1,7 @@
+u8 array = 4 | 6 | 8;
+print array[1 | 3];
+// 4 | 8
+
+u8 forceCon = [68];
+forceCon[1 | 2 | 6 | 7 | 11 | 52 | 57 | 58 | 65] = 10;
+print forceCon;

--- a/great_with_copyrights_backup.he
+++ b/great_with_copyrights_backup.he
@@ -1,0 +1,15 @@
+// Note
+// Step 1: Download xxx-master.zip from github
+// Step 2: Remove author info, and change function names
+// Step 3：Make a video
+// 
+// Author：He
+// 2024-11-22
+
+u8 array = 4 | 6 | 8;
+print array[1 | 3];
+// 4 | 8
+
+u8 forceCon = [68];
+forceCon[1 | 2 | 6 | 7 | 11 | 52 | 57 | 58 | 65] = 10;
+print forceCon;

--- a/helang/__main__.py
+++ b/helang/__main__.py
@@ -1,9 +1,15 @@
 from helang.lexer import Lexer
 from helang.parser import Parser
+from helang.notes_remover import NotesRemover
 
 
 if __name__ == '__main__':
-    with open('../great.he', 'r') as f:
+    script_path = '../great_with_copyrights.he'
+    
+    notesRemover = NotesRemover(script_path)
+    notesRemover.remove()
+    
+    with open('../great_with_copyrights.he', 'r') as f:
         content = f.read()
     lexer = Lexer(content)
     parser = Parser(lexer.lex())

--- a/helang/notes_remover.py
+++ b/helang/notes_remover.py
@@ -1,0 +1,30 @@
+class NotesRemover:
+    """ According to He's requirement, need to remove all the notes at the begaining of the code file.
+        Especially when there's orignal author signature
+    """    
+    
+    def __init__(self, path: str):
+        self.script_path = path
+        with open(self.script_path, 'r') as f:
+            self.contents = f.read().splitlines()
+        
+    
+    def remove(self):
+        lines_to_remove = 0
+        include_author = False
+        
+        for line in self.contents:
+            if line.lstrip().startswith('//') or line == '':
+                lines_to_remove += 1
+            else:
+                break
+            if 'author' in line.lower():
+                include_author = True
+        
+        self.contents = self.contents[lines_to_remove:]
+        
+        # New script here, no notes, no author signature, wonderfull for He!
+        with open(self.script_path, 'w') as f:
+            f.write('\n'.join(self.contents))
+        
+        


### PR DESCRIPTION
According to He's new requirement, notes and the begining of the script files are need to be removed, especially when there is author signature.

This feature remove HeLang's notes with author signature automatically before be complied.

![image](https://github.com/user-attachments/assets/5f389fc6-dbf5-4f71-a855-136c0be2aa85)
